### PR TITLE
Added support for metaclass

### DIFF
--- a/pyioc3/adapters.py
+++ b/pyioc3/adapters.py
@@ -1,4 +1,4 @@
-from .static_container import StaticContainer
+from .interface import Container
 
 
 class ValueAsImplAdapter:
@@ -26,6 +26,6 @@ class FactoryAsImplAdapter:
     def __init__(self, fn):
         self._fn = fn
 
-    def __call__(self, ctx: StaticContainer):
+    def __call__(self, ctx: Container):
         return self._fn(ctx)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,12 +1,15 @@
-from abc import ABC
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar, Iterator
 
 
 class DuckInterface(ABC):
+    @abstractmethod
     def quack(self):
         raise NotImplementedError()
 
 
 class QuackBehavior(ABC):
+    @abstractmethod
     def quack(self):
         raise NotImplementedError()
 
@@ -45,6 +48,38 @@ class HalfCircle1:
     def __init__(self, c: "HalfCircle2"):
         pass
 
+
 class HalfCircle2:
     def __init__(self, c: HalfCircle1):
+        pass
+
+
+DuckType = TypeVar("DuckType", bound="DuckInterface")
+
+
+class FlockInterface(Generic[DuckType]):
+    @abstractmethod
+    def __iter__(self) -> Iterator[DuckType]:
+        raise NotImplementedError()
+
+
+class FlockOfDucks(FlockInterface[DuckInterface]):
+    def __init__(self, ducka: DuckA, duckb: DuckB):
+        self._ducks = [ducka, duckb]
+    def __iter__(self) -> DuckInterface:
+        return iter(self._ducks)
+
+class Singleton(type):
+    _instances = None
+    def __call__(self, *args, **kwargs):
+        if not self._instances:
+            self._instances = super().__call__(*args, **kwargs)
+        return self._instances
+
+class MasterDuck(Singleton):
+    def __init__(self, quack: QuackBehavior):
+        pass
+
+class MetaMasterDuck(metaclass=Singleton):
+    def __init__(self, quack: QuackBehavior):
         pass

--- a/tests/test_bound_member.py
+++ b/tests/test_bound_member.py
@@ -1,23 +1,64 @@
 import unittest
+from types import FunctionType
+from random import randint, choice
+from pyioc3.interface import Container
 from pyioc3.bound_member import BoundMember
 from pyioc3.bound_member_factory import DefaultBoundMemberFactory
 from pyioc3.scope_enum import ScopeEnum
+from pyioc3.adapters import ValueAsImplAdapter, FunctionAsImplAdapter, FactoryAsImplAdapter
 
-from .fixtures import DuckA, DuckB, DuckC, duck_d, DuckInterface, QuackBehavior
+from .fixtures import (
+    DuckA,
+    DuckB,
+    DuckC,
+    duck_d,
+    DuckInterface,
+    QuackBehavior,
+    FlockOfDucks,
+    FlockInterface,
+    MasterDuck,
+    MetaMasterDuck,
+)
+
 
 class BoundMemberTest(unittest.TestCase):
-
 
     def test_expands_parameter_annotations_for_classes(self):
         factory = DefaultBoundMemberFactory()
         cases = [
-            (DuckA, [QuackBehavior]),
-            (DuckB, ["QuackBehavior"]),
-            (DuckC, []),
-            (duck_d, [QuackBehavior]),
+            (DuckInterface, DuckA, [QuackBehavior]),
+            (DuckInterface, DuckB, [QuackBehavior]),
+            (DuckInterface, DuckC, []),
+            ("foo", duck_d, [QuackBehavior]),
+            (FlockInterface[DuckInterface], FlockOfDucks, [DuckA, DuckB]),
+            ("lambda", lambda : 'x', []),
+            ("value", ValueAsImplAdapter(1), []),
+            ("function", FunctionAsImplAdapter(lambda : 'x'), []),
+            ("factory", FactoryAsImplAdapter(lambda: 'x'), [Container]),
+            (DuckInterface, MasterDuck, [QuackBehavior]),
+            (DuckInterface, MetaMasterDuck, [QuackBehavior])
         ]
-        for impl, result in cases:
+        for anno, impl, result in cases:
             with self.subTest(impl):
-                b = factory.build(DuckInterface, impl, ScopeEnum.TRANSIENT)
+                b = factory.build(anno, impl, ScopeEnum.TRANSIENT)
                 self.assertListEqual(b.parameters, result)
+
+    def test_ordering_of_parameter_annotations(self):
+        types = {
+            "int": int,
+            "str": str,
+            "bool": bool,
+        }
+        params = []
+        for i in range(255):
+            val = f"p{randint(1, 1000)}_{i}"
+            anno = choice(list(types.keys()))
+            params.append((val, anno))
+        args = ",".join([f"{p}: {a}" for p, a in params])
+        expected = [types[a] for _, a in params]
+        g = {}
+        exec(f"def func({args}):...", g)
+        factory = DefaultBoundMemberFactory()
+        b = factory.build("foo", g['func'], ScopeEnum.TRANSIENT)
+        self.assertListEqual(expected, b.parameters)
 


### PR DESCRIPTION
Changed the BoundMember factory to use get_type_hints to obtain annotation data.  Additionally added some logic to run the get_type_hits on the correct function from the implementation, `__init__`, `__call__` or the implementation itself.  This will add support for subclassing from classes that alter metaclass like typing.Generic or the common Singleton metaclass.