### PR TITLE
Added on-activate method

### DIFF
--- a/pyioc3/bound_member.py
+++ b/pyioc3/bound_member.py
@@ -8,13 +8,15 @@ class BoundMember:
         annotation: any,
         implementation: Callable,
         scope: ScopeEnum,
-        parameters: List[any]
+        parameters: List[any],
+        on_activate: Callable[[any],any] = None,
     ) -> None:
         self.annotation: any = annotation
         self.implementation: Callable = implementation
         self.scope: ScopeEnum = scope
         self.parameters: List[any] = parameters
         self._depends_on: List["BoundMember"] = []
+        self.on_activate: Callable[[any], any] = on_activate if on_activate else lambda x: x
 
     def bind_dependant(self, dependant: "BoundMember") -> None:
         self._depends_on.append(dependant)

--- a/pyioc3/bound_member_factory.py
+++ b/pyioc3/bound_member_factory.py
@@ -14,6 +14,7 @@ class DefaultBoundMemberFactory(BoundMemberFactory):
         annotation: any,
         implementation: Callable,
         scope: ScopeEnum,
+        on_activate: Callable[[Any], Any] = None,
     ) -> BoundMember:
 
         if isclass(implementation):
@@ -32,4 +33,5 @@ class DefaultBoundMemberFactory(BoundMemberFactory):
             implementation=implementation,
             scope=scope,
             parameters=[p for k, p in params.items() if k != 'return'],
+            on_activate=on_activate
         )

--- a/pyioc3/interface.py
+++ b/pyioc3/interface.py
@@ -70,7 +70,8 @@ class ContainerBuilder(ABC):
         self,
         annotation: any,
         implementation: Callable,
-        scope: ScopeEnum = ScopeEnum.TRANSIENT
+        scope: ScopeEnum = ScopeEnum.TRANSIENT,
+        on_activate: Callable[[any], any] = None,
     ):
         """Bind a class.
 
@@ -88,6 +89,11 @@ class ContainerBuilder(ABC):
           scope:          Identifies how the object should be cached. Options are
                           Transient, Requested, Singleton
                           Default: Transient.
+
+          on_activate:    An optional function that will be called with the
+                          constructed implementation before it is used as a dep
+                          or given as the return in container.get()
+                          Default: None.
 
         Scopes:
             Transient scopes and not cached.

--- a/pyioc3/scope_container.py
+++ b/pyioc3/scope_container.py
@@ -50,7 +50,7 @@ class ScopeContainer:
         args = list()
         for dep in member:
             args.append(self.get_instance_of(dep))
-        return member.implementation(*args)
+        return member.on_activate(member.implementation(*args))
 
     def _get_scope(self, member: BoundMember):
         return self._scopes[member.scope]

--- a/tests/test_bound_member.py
+++ b/tests/test_bound_member.py
@@ -61,4 +61,3 @@ class BoundMemberTest(unittest.TestCase):
         factory = DefaultBoundMemberFactory()
         b = factory.build("foo", g['func'], ScopeEnum.TRANSIENT)
         self.assertListEqual(expected, b.parameters)
-

--- a/tests/test_scope_container.py
+++ b/tests/test_scope_container.py
@@ -1,11 +1,12 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from pyioc3.scope_container import ScopeContainer
+from pyioc3.scope_container import ScopeContainer, PersistentScope
 from pyioc3.scope_enum import ScopeEnum
+from pyioc3.bound_member import BoundMember
 
 
-class ScopeContainerTests(unittest.TestCase):
+class ContainerScopeTests(unittest.TestCase):
 
     @patch("pyioc3.scope_container.PersistentScope")
     @patch("pyioc3.scope_container.TransientScope")
@@ -13,7 +14,7 @@ class ScopeContainerTests(unittest.TestCase):
 
         self.transient = transient()
         self.persistent = persistent()
-        self.singleton = MagicMock()
+        self.singleton = persistent()
         self.container = ScopeContainer(self.singleton)
 
         self.scope_cases = [
@@ -25,52 +26,146 @@ class ScopeContainerTests(unittest.TestCase):
     def test_add_uses_correct_scope(self):
         for scope_id, scope in self.scope_cases:
             with self.subTest(msg=scope_id):
-                member = MagicMock()
+                member = MagicMock(spec=BoundMember)
                 member.scope = scope_id
                 member.annotation = "foo"
                 member.implementation = MagicMock(return_value="bar")
+                member.on_activate = lambda x:x
                 self.container.add(member)
                 scope.add.assert_called_with("foo", "bar")
 
     def test_has_uses_correct_scope(self):
         for scope_id, scope in self.scope_cases:
             with self.subTest(msg=scope_id):
-                member = MagicMock()
+                member = MagicMock(spec=BoundMember)
                 member.scope = scope_id
                 member.annotation = "foo"
                 member.implementation = MagicMock(return_value="bar")
+                member.on_activate = lambda x:x
                 self.container.has(member)
                 scope.__contains__.assert_called_with("foo")
 
     def test_get_instance_of_uses_correct_scope(self):
         for scope_id, scope in self.scope_cases:
             with self.subTest(msg=scope_id):
-                member = MagicMock()
+                member = MagicMock(spec=BoundMember)
                 member.scope = scope_id
                 member.annotation = "foo"
                 member.implementation = MagicMock(return_value="bar")
+                member.on_activate = lambda x:x
                 self.container.get_instance_of(member)
                 scope.use.assert_called_with("foo")
 
+
+class ScopeContainerTests(unittest.TestCase):
+
+    def setUp(self):
+        self.container = ScopeContainer(PersistentScope())
+
     def test_creates_inst_with_deps(self):
 
-        a1 = MagicMock()
-        a1.scope = ScopeEnum.SINGLETON
-        a1.annotation="a1"
-        a1.implementation = MagicMock(return_value="a1_impl")
+        a1 = BoundMember(
+            annotation="a1",
+            implementation=lambda : "a1_impl",
+            scope=ScopeEnum.SINGLETON, 
+            parameters=[])
+        a1._depends_on=[]
         self.container.add(a1)
 
-        a2 = MagicMock()
-        a2.scope = ScopeEnum.SINGLETON
-        a2.annotation="a2"
-        a2.implementation = MagicMock(return_value="a2_impl")
+        a2 = BoundMember(
+            annotation="a2", 
+            implementation=lambda : "a2_impl",
+            scope=ScopeEnum.SINGLETON, 
+            parameters=[])
+        a2._depends_on=[]
         self.container.add(a2)
 
-        member = MagicMock()
-        member.scope = ScopeEnum.SINGLETON
-        member.annotation = "foo"
-        member.depends_on = [a1, a2]
-        member.implementation = MagicMock(return_value="bar")
+        impl = MagicMock()
+        member = BoundMember(
+            annotation="foo",
+            implementation=impl,
+            scope=ScopeEnum.SINGLETON,
+            parameters=["a1","a2"])
+        member._depends_on = [a1, a2]
         self.container.add(member)
 
-        member.implementation.called_with("a1_impl", "a2_impl")
+        impl.assert_called_with("a1_impl", "a2_impl")
+
+    def test_on_activate_called(self):
+        on_activate = MagicMock(return_value="baz")
+        member = BoundMember(
+            annotation="foo",
+            implementation=lambda : "bar",
+            scope=ScopeEnum.SINGLETON,
+            parameters=["a1","a2"],
+            on_activate=on_activate)
+        member._depends_on = []
+        self.container.add(member)
+        on_activate.assert_called_with("bar")
+
+
+    def test_on_activate_called_once_if_singleton(self):
+
+        on_activate = MagicMock(return_value="baz")
+
+        a1 = BoundMember(
+            annotation="a1",
+            implementation=lambda : "a1_impl",
+            scope=ScopeEnum.SINGLETON, 
+            parameters=[],
+            on_activate=on_activate)
+        a1._depends_on=[]
+
+        a2 = BoundMember(
+            annotation="a2", 
+            implementation=lambda a : "a2_impl",
+            scope=ScopeEnum.SINGLETON, 
+            parameters=["a1"])
+        a2._depends_on=[a1]
+
+        member = BoundMember(
+            annotation="foo",
+            implementation=lambda a, b: "bar",
+            scope=ScopeEnum.SINGLETON,
+            parameters=["a1","a2"])
+        member._depends_on = [a1, a2]
+
+        self.container.add(a1)
+        self.container.add(a2)
+        self.container.add(member)
+
+        on_activate.assert_called_once_with("a1_impl")
+
+
+    def test_on_activate_called_for_each_instance_if_transient(self):
+
+        on_activate = MagicMock(return_value="baz")
+
+        a1 = BoundMember(
+            annotation="a1",
+            implementation=lambda : "a1_impl",
+            scope=ScopeEnum.TRANSIENT, 
+            parameters=[],
+            on_activate=on_activate)
+        a1._depends_on=[]
+
+        a2 = BoundMember(
+            annotation="a2", 
+            implementation=lambda a : "a2_impl",
+            scope=ScopeEnum.SINGLETON, 
+            parameters=["a1"])
+        a2._depends_on=[a1]
+
+        member = BoundMember(
+            annotation="foo",
+            implementation=lambda a, b: "bar",
+            scope=ScopeEnum.SINGLETON,
+            parameters=["a1","a2"])
+        member._depends_on = [a1, a2]
+
+        self.container.add(a1)
+        self.container.add(a1)
+        self.container.add(a2)
+        self.container.add(member)
+
+        self.assertEqual(2, on_activate.call_count)


### PR DESCRIPTION
Added on-activate as an optional argument to bind. This will allow the ioc setup to offer a activation function to pass the newly created instance into.  Useful for things like setting strategies or configuration data.